### PR TITLE
Fix:  WebDriver-session was overriden

### DIFF
--- a/galen-bootstrap/devices.js
+++ b/galen-bootstrap/devices.js
@@ -32,16 +32,17 @@ function inSeleniumGrid(gridUrl, deviceName, tags, gridSettings) {
         deviceName: deviceName,
         tags: tags,
         initDriver: function (url) {
-            this.driver = createGridDriver(gridUrl, gridSettings);
+            var driver = createGridDriver(gridUrl, gridSettings);
 
             if (url !== null) {
-                this.driver.get(url);
+                driver.get(url);
             }
 
-            return this.driver;
+            return driver;
         },
         quit: function () {
-            this.driver && this.driver.quit();
+            var driver = session.get("driver");
+            driver && driver.quit();
         }
     });
 }


### PR DESCRIPTION
The previous version seemed not to be thread-safe since a NoSuchSessionException sometimes occurred when running tests in parallel in a Selenium Grid. This seems to be caused by an override of the driver property of the device from another thread, causing two tests to use the same WebDriver-session which in turn leads to an Exception when the first test to finish closes the driver-session. By only accessing the driver through the TestSession (where it is set anyway, see also https://github.com/galenframework/galen-bootstrap/blob/master/galen-bootstrap/galen-bootstrap.js#L94), we can avoid using a non-thread-local driver instance.